### PR TITLE
Fix missing polygons, less computations

### DIFF
--- a/src/models/MVTStyles/AtomicBordersModel.js
+++ b/src/models/MVTStyles/AtomicBordersModel.js
@@ -28,49 +28,55 @@ export default class AtomicBordersModel {
 
   @observable layerName = 'ap';
 
+  @observable mapsOpacity = 0.75;
+
+  @observable debug = false;
+
+  @computed get fallback() {
+    return this.debug
+      // bright green for debug purposes
+      ? 'rgb(0, 255, 0)'
+      // transparent fallback color
+      : 'hsla(0, 14%, 87%, 0)';
+  }
+
+  @computed get paint() {
+    return {
+      'fill-opacity': this.mapsOpacity,
+      'fill-outline-color': this.debug ? 'rgb(30, 30, 200)' : this.fallback,
+      'fill-color': ['match', ['get', 'id'], ...this.fill, this.fallback],
+    };
+  }
+
   @computed get STVs() {
     return this.rootStore.spaceTimeVolume;
   }
 
   @computed get fill() {
-    console.time('StyleFeatures');
     const res = Object.values(this.STVs.current).reduce((prev, stv) => (
-      [...prev, stv.data.territory, `rgb(${stv.color})`]
+      [...prev, stv.data.territory, stv.color]
     ), []);
-    console.timeEnd('StyleFeatures');
     return res;
   }
 
-  @computed get styleInfo() {
-    const name = this.layerName;
-
-    const mapsOpacity = 0.75;
-
-    const source = {
+  @computed get source() {
+    return {
       type: 'vector',
-      tiles: [`${window.location.origin}/mvt/${name}/{z}/{x}/{y}`]
+      tiles: [`${window.location.origin}/mvt/${this.layerName}/{z}/{x}/{y}`]
     };
+  }
 
-    // transparent fallback color
-    const fallback = 'hsla(0, 14%, 87%, 0)';
-    // bright green for debug purposes
-    // const fallback = 'rgb(0, 255, 0)';
-
+  @computed get styleInfo() {
     const layer = {
       layout: {},
       type: 'fill',
-      source: name,
-      id: name,
-      paint: {
-        'fill-opacity': mapsOpacity,
-        'fill-color': ['match', ['get', 'id'], ...this.fill, fallback],
-        'fill-outline-color': fallback,
-        // 'fill-outline-color': 'rgb(30, 30, 200)',
-      },
-      'source-layer': name
+      source: this.layerName,
+      id: this.layerName,
+      paint: this.paint,
+      'source-layer': this.layerName
     };
     return {
-      sources: { [name]: source }, layers: [layer]
+      sources: { [this.layerName]: this.source }, layers: [layer]
     };
   }
 }

--- a/src/models/MVTStyles/AtomicBordersModel.js
+++ b/src/models/MVTStyles/AtomicBordersModel.js
@@ -58,7 +58,6 @@ export default class AtomicBordersModel {
 
     const layer = {
       layout: {},
-      filter: ['in', 'id', ...Object.keys(this.STVs.active).map(m => Number(m))],
       type: 'fill',
       source: name,
       id: name,

--- a/src/models/SpaceTimeVolumes/SpaceTimeVolumeModel.js
+++ b/src/models/SpaceTimeVolumes/SpaceTimeVolumeModel.js
@@ -77,11 +77,11 @@ export default class SpaceTimeVolume {
   @computed get color() {
     try {
       const color = this.mapColors[this.te.color].color1;
-      return [color[0], color[1], color[2]];
+      return `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
     } catch (e) {
       // console.error('ColorID', this.data.color, 'Props', this.data);
       // Probably colorID === -99 -- Disputed territory
-      return [127, 127, 127];
+      return 'rgb(127, 127, 127)';
     }
   }
 

--- a/src/models/SpaceTimeVolumes/SpaceTimeVolumeModel.js
+++ b/src/models/SpaceTimeVolumes/SpaceTimeVolumeModel.js
@@ -28,7 +28,7 @@ export default class SpaceTimeVolume {
   }
 
   @computed get inUse() {
-    return this.data.territory.reduce((p, c) => ({ ...p, [c]: true }));
+    return this.data.territory.reduce((p, c) => ({ ...p, [c]: true }), {});
   }
 
   @computed get wId() {

--- a/src/models/SpaceTimeVolumes/SpaceTimeVolumeModel.js
+++ b/src/models/SpaceTimeVolumes/SpaceTimeVolumeModel.js
@@ -27,10 +27,6 @@ export default class SpaceTimeVolume {
     return (this.startDate <= this.now && this.now <= this.endDate);
   }
 
-  @computed get inUse() {
-    return this.data.territory.reduce((p, c) => ({ ...p, [c]: true }), {});
-  }
-
   @computed get wId() {
     return `Q${this.te.wikidata_id}`;
   }

--- a/src/models/SpaceTimeVolumes/SpaceTimeVolumesContainer.js
+++ b/src/models/SpaceTimeVolumes/SpaceTimeVolumesContainer.js
@@ -31,13 +31,6 @@ export default class SpaceTimeVolumeModel {
         : prev), {});
   }
 
-  @computed get active() {
-    return Object.keys(this.current).reduce((prev, key) => ({
-      ...prev,
-      ...this.current[key].inUse
-    }), {});
-  }
-
   @computed get wIds() {
     return Object.keys(this.current).map(stv => this.current[stv].wId);
   }
@@ -52,7 +45,6 @@ export default class SpaceTimeVolumeModel {
       }
     }
     return null;
-    // return this.ap2stv[id].filter(f => this.data[f].visible);
   }
 
   constructor(rootStore) {


### PR DESCRIPTION
There was a bug in `inUse` getter, initial value for reduce function was not set, because of that fist polygon in STV was lost
Example:
![image](https://user-images.githubusercontent.com/61106/53298341-bb15df00-382c-11e9-8f2c-68222865a533.png)

`inUse` getter was originally designed for debug purposes for overlapping territories, and we don't need it anymore. We don't need filter in MVT style either

Added debug toggle for borders
Entering in web console will toggle AP stroke and fill color for unused APs
`window.store.mapStyle.atomicBorders.debug = true`
