### PR TITLE
Fix detached dashboard in safari

### DIFF
--- a/src/containers/DashboardFooter/DashboardFooter.less
+++ b/src/containers/DashboardFooter/DashboardFooter.less
@@ -7,7 +7,8 @@
   transform: translateX(3px);
   border: 1px solid @footer-border;
   background-color: @footer-background;
-  margin: calc(55px + 0.75rem) 0;
+  margin-top: 0.75rem;
+  margin-bottom: calc(55px + 0.75rem);
   height: 2rem;
   padding: 0.1rem;
   display: flex;

--- a/src/containers/DashboardFooter/DashboardFooter.less
+++ b/src/containers/DashboardFooter/DashboardFooter.less
@@ -7,7 +7,7 @@
   transform: translateX(3px);
   border: 1px solid @footer-border;
   background-color: @footer-background;
-  margin: 0.75rem 0;
+  margin: calc(55px + 0.75rem) 0;
   height: 2rem;
   padding: 0.1rem;
   display: flex;

--- a/src/templates/Dashboard/Dashboard.less
+++ b/src/templates/Dashboard/Dashboard.less
@@ -12,7 +12,7 @@
   padding: 0rem;
   transform: translateX(0);
   transition: transform 300ms ease-in-out;
-  z-index: 8;
+  z-index: 7;
   &__hidden {
     transform: translateX(-400px);
   }

--- a/src/templates/Dashboard/Dashboard.less
+++ b/src/templates/Dashboard/Dashboard.less
@@ -6,13 +6,13 @@
   flex-direction: column;
   left: 0;
   top: 0;
-  height: calc(~'100vh - 55px');
+  height: 100vh;
   width: 400px;
   background-color: rgba(@panel, 0.7);
   padding: 0rem;
   transform: translateX(0);
   transition: transform 300ms ease-in-out;
-  z-index: 40;
+  z-index: 8;
   &__hidden {
     transform: translateX(-400px);
   }


### PR DESCRIPTION
After receiving a pop-up message `This webpage is using significant memory (or energy). Closing it may improve the responsiveness of your Mac` dashboard became detached from timepanel

![image](https://user-images.githubusercontent.com/61106/53500357-739c8680-3aaa-11e9-993b-d239ed6c582f.png)
![image](https://user-images.githubusercontent.com/61106/53500367-7b5c2b00-3aaa-11e9-8fcb-fbfdc93886dd.png)

Should work properly now