### PR TITLE
Fix borders in narratives

### DIFF
--- a/src/models/YearModel.js
+++ b/src/models/YearModel.js
@@ -109,7 +109,7 @@ export default class YearModel {
         const mapSetting = this.rootStore.data.mapSettings.data[narration.settings];
         this.rootStore.deck.updateSettings(mapSetting);
       }
-      this.setYear(narration.map_datetime.split('-')[0]);
+      this.setYear(Number(narration.map_datetime.split('-')[0]));
       this.tick = tick;
       // Fetch free data for free pins
       this.rootStore.wikidata.getItems(this.rootStore.pins.narrationFreeDeps);


### PR DESCRIPTION
Year from narrative was stored as a string instead of integer

Due to new MVT filters introduced in #57 that fact is now matters.

Substring selection would be changed after migrating to JDN https://github.com/chronhq/backend/issues/93