### PR TITLE
Fix sources in balloon for pins

### DIFF
--- a/src/components/Messages/Sources.js
+++ b/src/components/Messages/Sources.js
@@ -73,9 +73,9 @@ class Sources extends React.Component {
   }
 
   @computed get item() {
-    const wId = this.props.id.match(/^Q/)
-      ? this.props.id
-      : `Q${this.props.id}`;
+    const wId = Number(this.props.id)
+      ? `Q${this.props.id}`
+      : this.props.id;
     const sources = this.props.type === 'countryHover'
       ? JSON.parse(this.props.data.references)
       : undefined;

--- a/src/components/Messages/Sources.js
+++ b/src/components/Messages/Sources.js
@@ -73,7 +73,9 @@ class Sources extends React.Component {
   }
 
   @computed get item() {
-    const wId = `Q${this.props.id}`;
+    const wId = this.props.id.match(/^Q/)
+      ? this.props.id
+      : `Q${this.props.id}`;
     const sources = this.props.type === 'countryHover'
       ? JSON.parse(this.props.data.references)
       : undefined;


### PR DESCRIPTION
Due to code inconsistency about wikidata ids in #57 was added a new bug

before | after
-- | --
![image](https://user-images.githubusercontent.com/61106/55082875-c023b380-50a2-11e9-8427-2b608eea7f24.png) | ![image](https://user-images.githubusercontent.com/61106/55082838-af733d80-50a2-11e9-9a37-f1a8c19ea87b.png)
